### PR TITLE
클래스형 컴포넌트에서 함수형 컴포넌트로 변경, 주석 추가

### DIFF
--- a/src/component/TodoInput.tsx
+++ b/src/component/TodoInput.tsx
@@ -10,23 +10,46 @@ interface Props extends TodoListState {
   onKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
-export default class TodoInput extends React.Component<Props> {
-  render() {
-    const { inputText, onChange, onClick, onKeyPress } = this.props;
-    return (
-      <TodoInputDiv>
-        <TodoTextInput
-          value={inputText} // change 되면서 입력된 데이터를 value로
-          placeholder="오늘 할 일을 작성해보세요."
-          onChange={(e) => onChange(e)}
-          onKeyPress={(e) => onKeyPress(e)}
-        ></TodoTextInput>
-        <CreateBtn onClick={onClick}>등록</CreateBtn>
-        <TodoItemListDiv></TodoItemListDiv>
-      </TodoInputDiv>
-    );
-  }
+// 함수형 컴포넌트로 변경 => state 선언과 props만 받아와서 사용하면 될 경우 사용
+// function 함수명 (props: {props 타입}) { return {} ;}
+export default function TodoInput({
+  inputText,
+  onChange,
+  onClick,
+  onKeyPress,
+}: Props) {
+  return (
+    <TodoInputDiv>
+      <TodoTextInput
+        value={inputText} // change 되면서 입력된 데이터를 value로
+        placeholder="오늘 할 일을 작성해보세요."
+        onChange={(e) => onChange(e)}
+        onKeyPress={(e) => onKeyPress(e)}
+      ></TodoTextInput>
+      <CreateBtn onClick={onClick}>등록</CreateBtn>
+      <TodoItemListDiv></TodoItemListDiv>
+    </TodoInputDiv>
+  );
 }
+
+// 클래스형 컴포넌트
+// export default class TodoInput extends React.Component<Props> {
+//   render() {
+//     const { inputText, onChange, onClick, onKeyPress } = this.props;
+//     return (
+//       <TodoInputDiv>
+//         <TodoTextInput
+//           value={inputText} // change 되면서 입력된 데이터를 value로
+//           placeholder="오늘 할 일을 작성해보세요."
+//           onChange={(e) => onChange(e)}
+//           onKeyPress={(e) => onKeyPress(e)}
+//         ></TodoTextInput>
+//         <CreateBtn onClick={onClick}>등록</CreateBtn>
+//         <TodoItemListDiv></TodoItemListDiv>
+//       </TodoInputDiv>
+//     );
+//   }
+// }
 
 const TodoTextInput = styled.input`
   border: none;

--- a/src/component/TodoInput.tsx
+++ b/src/component/TodoInput.tsx
@@ -18,6 +18,7 @@ export default function TodoInput({
   onClick,
   onKeyPress,
 }: Props) {
+  // 함수형 컴포넌트에서는 props를 불러올 필요 없이 사용 가능하다
   return (
     <TodoInputDiv>
       <TodoTextInput

--- a/src/component/TodoItemList.tsx
+++ b/src/component/TodoItemList.tsx
@@ -11,44 +11,82 @@ interface Props extends TodoListState {
   onKeyPress: (e: React.KeyboardEvent<HTMLInputElement>, id: number) => void;
 }
 
-export default class TodoItemList extends React.Component<Props> {
-  render() {
-    const {
-      todos,
-      onClick,
-      onToggle,
-      onUpdate,
-      onUpdateChange,
-      onKeyPress,
-    } = this.props;
-    const todoItemList = todos.map(({ id, text, checked, updated }) => (
-      <TodoItemListDiv key={id}>
-        <TodoItemDiv
-          className={checked ? "checked" : ""}
-          onClick={() => onToggle(id)}
-          onDoubleClick={() => onUpdate(id)}
+// 함수형 컴포넌트로 변경
+export default function TodoItemList({
+  todos,
+  onClick,
+  onToggle,
+  onUpdate,
+  onUpdateChange,
+  onKeyPress,
+}: Props) {
+  const todoItemList = todos.map(({ id, text, checked, updated }) => (
+    <TodoItemListDiv key={id}>
+      <TodoItemDiv
+        className={checked ? "checked" : ""} // checked가 true면 클래스명이 "checked", false면 ""
+        onClick={() => onToggle(id)}
+        onDoubleClick={() => onUpdate(id)}
+      >
+        {text}
+        <DeleteBtn
+          onClick={(e) => {
+            e.stopPropagation(); // 부모의 이벤트 동작하지 않도록(이벤트 버블링 방지)
+            onClick(id);
+          }}
         >
-          {text}
-          <DeleteBtn
-            onClick={(e) => {
-              e.stopPropagation(); // 부모의 이벤트 동작하지 않도록
-              onClick(id);
-            }}
-          >
-            <i className="fas fa-trash-alt"></i>
-          </DeleteBtn>
-        </TodoItemDiv>
-        <UpdatedInput
-          className={updated ? "updated" : ""}
-          placeholder="수정할 내용을 작성하고 엔터를 누르세요."
-          onChange={(e) => onUpdateChange(e, id)}
-          onKeyUp={(e) => onKeyPress(e, id)}
-        ></UpdatedInput>
-      </TodoItemListDiv>
-    ));
-    return <TodoItemListDiv2>{todoItemList}</TodoItemListDiv2>;
-  }
+          <i className="fas fa-trash-alt"></i>
+        </DeleteBtn>
+      </TodoItemDiv>
+      <UpdatedInput
+        className={updated ? "updated" : ""} // updated가 true면 클래스명이 "updated", false면 ""
+        placeholder="수정할 내용을 작성하고 엔터를 누르세요."
+        onChange={(e) => onUpdateChange(e, id)}
+        onKeyUp={(e) => onKeyPress(e, id)}
+      ></UpdatedInput>
+    </TodoItemListDiv>
+  ));
+  return <TodoItemListDiv2>{todoItemList}</TodoItemListDiv2>;
 }
+
+// 클래스형 컴포넌트
+// export default class TodoItemList extends React.Component<Props> {
+//   render() {
+//     const {
+//       todos,
+//       onClick,
+//       onToggle,
+//       onUpdate,
+//       onUpdateChange,
+//       onKeyPress,
+//     } = this.props;
+//     const todoItemList = todos.map(({ id, text, checked, updated }) => (
+//       <TodoItemListDiv key={id}>
+//         <TodoItemDiv
+//           className={checked ? "checked" : ""}
+//           onClick={() => onToggle(id)}
+//           onDoubleClick={() => onUpdate(id)}
+//         >
+//           {text}
+//           <DeleteBtn
+//             onClick={(e) => {
+//               e.stopPropagation(); // 부모의 이벤트 동작하지 않도록
+//               onClick(id);
+//             }}
+//           >
+//             <i className="fas fa-trash-alt"></i>
+//           </DeleteBtn>
+//         </TodoItemDiv>
+//         <UpdatedInput
+//           className={updated ? "updated" : ""}
+//           placeholder="수정할 내용을 작성하고 엔터를 누르세요."
+//           onChange={(e) => onUpdateChange(e, id)}
+//           onKeyUp={(e) => onKeyPress(e, id)}
+//         ></UpdatedInput>
+//       </TodoItemListDiv>
+//     ));
+//     return <TodoItemListDiv2>{todoItemList}</TodoItemListDiv2>;
+//   }
+// }
 
 const TodoItemListDiv = styled.div`
   padding: 10px;

--- a/src/component/TodoList.tsx
+++ b/src/component/TodoList.tsx
@@ -63,6 +63,7 @@ export default class TodoList extends React.Component<{}, State> {
   };
   // 할 일 추가 Change, Click, KeyPress
   handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // 타입스크립트를 사용할 경우 이벤트에 대한 타입 지정도 필요함
     this.setState({
       inputText: e.target.value,
     });


### PR DESCRIPTION
[참고 자료](https://velog.io/@sdc337dc/0.%ED%81%B4%EB%9E%98%EC%8A%A4%ED%98%95-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8)
1. 함수형 컴포넌트는 state를 갖지 못하므로 setState 사용 불가, life-cycle 함수 사용 불가
-> 이는 Hook을 통해 해결 가능하다(!)
2. 함수형 컴포넌트의 props는 불러올 필요 없이 바로 호출할 수 있다.
